### PR TITLE
StateStore model base classes and gRPC wrapper.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 The Dapr Authors.
+   Copyright 2023 The Dapr Authors.
 
    and others that have contributed code to the public domain.
 

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-  Copyright 2021 The Dapr Authors
+  Copyright 2023 The Dapr Authors
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at

--- a/components-java-sdk/pom.xml
+++ b/components-java-sdk/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.dapr</groupId>
+        <artifactId>components-java-sdk-parent</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>components-java-sdk</artifactId>
+    <packaging>jar</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>components-java-sdk</name>
+    <description>SDK for developing Dapr pluggable containers in java</description>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.dapr</groupId>
+            <artifactId>components-java-sdk-autogen</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-core</artifactId>
+            <version>3.3.11.RELEASE</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/components-java-sdk/src/main/java/io/dapr/components/aspects/AdvertisesFeatures.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/aspects/AdvertisesFeatures.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.aspects;
+
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+public interface AdvertisesFeatures {
+  Mono<List<String>> getFeatures();
+}

--- a/components-java-sdk/src/main/java/io/dapr/components/aspects/InitializableWithProperties.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/aspects/InitializableWithProperties.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.aspects;
+
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+
+public interface InitializableWithProperties {
+  Mono<Void> init(Map<String, String> properties);
+}

--- a/components-java-sdk/src/main/java/io/dapr/components/aspects/Pingable.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/aspects/Pingable.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.aspects;
+
+import reactor.core.publisher.Mono;
+
+public interface Pingable {
+  Mono<Void> ping();
+}

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/BulkGetError.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/BulkGetError.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.domain.state;
+
+public class BulkGetError {
+  public static final String KEY_DOES_NOT_EXIST = "KeyDoesNotExist";
+  public static final String NONE = "none";
+}

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/DeleteRequest.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/DeleteRequest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.domain.state;
+
+import dapr.proto.components.v1.State;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Delete request.
+ *
+ * @param key The key that should be deleted.
+ * @param etag The etag is used as a If-Match header, to allow certain levels of consistency.
+ * @param metadata The request metadata.
+ * @param options Consistency and concurrency options.
+ */
+public record DeleteRequest(String key, String etag, Map<String, String> metadata, StateOptions options) {
+
+  /**
+   * Constructor.
+   *
+   * @param key The key that should be deleted.
+   * @param etag The etag is used as a If-Match header, to allow certain levels of consistency.
+   * @param metadata The request metadata.
+   * @param options Consistency and concurrency options.
+   */
+  public DeleteRequest(String key, String etag, Map<String, String> metadata, StateOptions options) {
+    this.key = Objects.requireNonNull(key);
+    this.etag = Objects.requireNonNull(etag);
+    // All this constructor just so we can make this Map unmodifiable and this class immutable ;)
+    this.metadata = Collections.unmodifiableMap(Objects.requireNonNull(metadata));
+    this.options = Objects.requireNonNull(options);
+  }
+
+  /**
+   * Conversion constructor.
+   *
+   * @param other The Protocol Buffer representation of a SetRequest.
+   */
+  public DeleteRequest(dapr.proto.components.v1.State.DeleteRequest other) {
+    this(other.getKey(),
+        other.getEtag().getValue(),
+        other.getMetadataMap(),
+        new StateOptions(other.getOptions()));
+  }
+}

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/GetRequest.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/GetRequest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.domain.state;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * The SDK representation of a StateStore#get request.
+ *
+ * @param key The key that should be retrieved.
+ * @param metadata Request associated metadata.
+ * @param consistency The get consistency level.
+ */
+public record GetRequest(String key, Map<String, String> metadata, StateOptions.StateConsistency consistency) {
+
+  /**
+   * Constructor.
+   *
+   * @param key The key that should be retrieved.
+   * @param metadata Request associated metadata.
+   * @param consistency The get consistency level.
+   */
+  public GetRequest(String key, Map<String, String> metadata, StateOptions.StateConsistency consistency) {
+    this.key = Objects.requireNonNull(key);
+    this.metadata = Collections.unmodifiableMap(Objects.requireNonNull(metadata));
+    this.consistency = Objects.requireNonNull(consistency);
+  }
+
+  /**
+   * Conversion constructor.
+   *
+   * @param other The Protocol Buffer representation of a GetRequest
+   */
+  public GetRequest(dapr.proto.components.v1.State.GetRequest other) {
+    this(other.getKey(),
+        other.getMetadataMap(),
+        StateOptions.StateConsistency.of(other.getConsistency()));
+  }
+}

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/GetResponse.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/GetResponse.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.domain.state;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Response for a StateStore#get request.
+ *
+ * @param data The value of the GetRequest response.
+ * @param etag The etag of the associated key.
+ * @param metadata Metadata related to the response.
+ * @param contentType The response value contenttype
+ */
+public record GetResponse(byte[] data, String etag, Map<String, String> metadata, String contentType) {
+
+  /**
+   * Constructor.
+   *
+   * @param data The value of the GetRequest response.
+   * @param etag The etag of the associated key.
+   * @param metadata Metadata related to the response.
+   * @param contentType The response value contenttype
+   */
+  public GetResponse(byte[] data, String etag, Map<String, String> metadata, String contentType) {
+    this.data = Objects.requireNonNull(data);
+    this.etag = Objects.requireNonNull(etag);
+    // All this constructor just so we can make this Map unmodifiable and this class immutable ;)
+    this.metadata = Collections.unmodifiableMap(Objects.requireNonNull(metadata));
+    this.contentType = Objects.requireNonNull(contentType);
+  }
+}

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/SetRequest.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/SetRequest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.domain.state;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Model for a stateStore.set request.
+ *
+ * @param key The key that should be set.
+ * @param value Value is the desired content of the given key.
+ * @param etag The etag is used as a If-Match header, to allow certain levels of consistency.
+ * @param metadata The request metadata.
+ * @param options The Set request options.
+ * @param contentType The value contenttype.
+ */
+public record SetRequest(String key, byte[] value, String etag, Map<String, String> metadata, StateOptions options,
+                         String contentType) {
+  /**
+   * Constructor.
+   *
+   * @param key The key that should be set.
+   * @param value Value is the desired content of the given key.
+   * @param etag The etag is used as a If-Match header, to allow certain levels of consistency.
+   * @param metadata The request metadata.
+   * @param options The Set request options.
+   * @param contentType The value contenttype.
+   */
+  public SetRequest(String key, byte[] value, String etag, Map<String, String> metadata, StateOptions options,
+                    String contentType) {
+    this.key = Objects.requireNonNull(key);
+    this.value = Objects.requireNonNull(value);
+    this.etag = Objects.requireNonNull(etag);
+    // All this constructor just so we can make this Map unmodifiable and this class immutable ;)
+    this.metadata = Collections.unmodifiableMap(Objects.requireNonNull(metadata));
+    this.options = Objects.requireNonNull(options);
+    this.contentType = Objects.requireNonNull(contentType);
+  }
+
+  /**
+   * Conversion constructor.
+   *
+   * @param other The Protocol Buffer representation of a SetRequest.
+   */
+  public SetRequest(dapr.proto.components.v1.State.SetRequest other) {
+    this(other.getKey(),
+        other.getValue().toByteArray(),
+        other.getEtag().getValue(),
+        other.getMetadataMap(),
+        new StateOptions(other.getOptions()),
+        other.getContentType());
+  }
+}

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/StateOptions.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/StateOptions.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.domain.state;
+
+import dapr.proto.components.v1.State;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public record StateOptions(StateConcurrency concurrency, StateConsistency consistency) {
+
+  public StateOptions {
+    Objects.requireNonNull(concurrency);
+    Objects.requireNonNull(consistency);
+  }
+
+  public StateOptions(State.StateOptions other) {
+    this(StateConcurrency.of(other.getConcurrency()), StateConsistency.of(other.getConsistency()));
+  }
+
+  /**
+   * Enum describing the supported concurrency for state.
+   */
+  public enum StateConcurrency {
+    UNSPECIFIED(State.StateOptions.StateConcurrency.CONCURRENCY_UNSPECIFIED),
+
+    FIRST_WRITE(State.StateOptions.StateConcurrency.CONCURRENCY_FIRST_WRITE),
+
+    LAST_WRITE(State.StateOptions.StateConcurrency.CONCURRENCY_LAST_WRITE);
+
+    // The gRPC equivalent for this enum
+    private final State.StateOptions.StateConcurrency equivalent;
+
+    // Convert Protocol Buffer model to this SDK internal Model
+    static final Map<State.StateOptions.StateConcurrency, StateConcurrency> toSdkModel =
+        Arrays.stream(StateConcurrency.values())
+            .collect(Collectors.toMap(StateConcurrency::getValue, Function.identity()));
+
+
+    StateConcurrency(State.StateOptions.StateConcurrency value) {
+      this.equivalent = value;
+    }
+
+    public State.StateOptions.StateConcurrency getValue() {
+      return this.equivalent;
+    }
+
+    public static StateConcurrency of(State.StateOptions.StateConcurrency value) {
+      return toSdkModel.get(value);
+    }
+  }
+
+  /**
+   * Enum describing the supported consistency for state.
+   */
+  enum StateConsistency {
+    UNSPECIFIED(State.StateOptions.StateConsistency.CONSISTENCY_UNSPECIFIED),
+    EVENTUAL(State.StateOptions.StateConsistency.CONSISTENCY_EVENTUAL),
+    STRONG(State.StateOptions.StateConsistency.CONSISTENCY_STRONG);
+
+    private final State.StateOptions.StateConsistency equivalent;
+
+    // Convert Protocol Buffer model to this SDK internal Model
+    static final Map<State.StateOptions.StateConsistency, StateConsistency> toSdkModel =
+        Arrays.stream(StateConsistency.values())
+            .collect(Collectors.toMap(StateConsistency::getValue, Function.identity()));
+
+    StateConsistency(State.StateOptions.StateConsistency value) {
+      this.equivalent = value;
+    }
+
+    public State.StateOptions.StateConsistency getValue() {
+      return this.equivalent;
+    }
+
+    public static StateConsistency of(State.StateOptions.StateConsistency value) {
+      return toSdkModel.get(value);
+    }
+  }
+}

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/StateStore.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/StateStore.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.domain.state;
+
+import io.dapr.components.aspects.AdvertisesFeatures;
+import io.dapr.components.aspects.InitializableWithProperties;
+import io.dapr.components.aspects.Pingable;
+import reactor.core.publisher.Mono;
+
+
+public interface StateStore extends InitializableWithProperties, AdvertisesFeatures, Pingable {
+  Mono<GetResponse> get(GetRequest getRequest);
+
+  Mono<Void> delete(DeleteRequest deleteRequest);
+
+  Mono<Void> set(SetRequest setRequeset);
+}

--- a/components-java-sdk/src/main/java/io/dapr/components/wrappers/StateStoreGrpcComponentWrapper.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/wrappers/StateStoreGrpcComponentWrapper.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.wrappers;
+
+import com.google.protobuf.ByteString;
+import dapr.proto.components.v1.State;
+import dapr.proto.components.v1.State.BulkDeleteRequest;
+import dapr.proto.components.v1.State.BulkGetRequest;
+import dapr.proto.components.v1.State.BulkGetResponse;
+import dapr.proto.components.v1.State.BulkSetRequest;
+import dapr.proto.components.v1.State.BulkStateItem;
+import dapr.proto.components.v1.State.DeleteRequest;
+import dapr.proto.components.v1.State.Etag;
+import dapr.proto.components.v1.State.GetRequest;
+import dapr.proto.components.v1.StateStoreGrpc;
+import io.dapr.components.domain.state.BulkGetError;
+import io.dapr.components.domain.state.SetRequest;
+import io.dapr.components.domain.state.StateStore;
+import io.dapr.v1.ComponentProtos;
+import io.dapr.v1.ComponentProtos.FeaturesResponse;
+import io.grpc.stub.StreamObserver;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Objects;
+
+/**
+ * A translation layer between a (local) StateStore implementation and Dapr's gRPC StateStore model.
+ */
+public class StateStoreGrpcComponentWrapper extends StateStoreGrpc.StateStoreImplBase {
+  private static final Etag EMPTY_ETAG = Etag.newBuilder().setValue("").build();
+  private static final State.GetResponse EMPTY_GET_RESPONSE = State.GetResponse.newBuilder()
+      .setData(ByteString.EMPTY)
+      .setEtag(EMPTY_ETAG)
+      .build();
+
+  /**
+   * The state store that this component will expose as a service.
+   */
+  private final StateStore stateStore;
+
+  public StateStoreGrpcComponentWrapper(final StateStore stateStore) {
+    this.stateStore = Objects.requireNonNull(stateStore);
+  }
+
+  @Override
+  public void init(final State.InitRequest request, final StreamObserver<State.InitResponse> responseObserver) {
+    Mono.just(request)
+        .flatMap(req -> stateStore.init(req.getMetadata().getPropertiesMap()))
+        // Response is functionally and structurally equivalent to Empty, nothing to fill.
+        .map(response -> State.InitResponse.getDefaultInstance())
+        .subscribe(responseObserver::onNext, responseObserver::onError, responseObserver::onCompleted);
+  }
+
+  @Override
+  public void features(final ComponentProtos.FeaturesRequest request,
+                       final StreamObserver<FeaturesResponse> responseObserver) {
+    Mono.just(request)
+        .flatMap(req -> stateStore.getFeatures())
+        .map(features -> FeaturesResponse.newBuilder()
+            .addAllFeatures(features)
+            .build()
+        )
+        .subscribe(responseObserver::onNext, responseObserver::onError, responseObserver::onCompleted);
+  }
+
+  @Override
+  public void delete(final DeleteRequest request, final StreamObserver<State.DeleteResponse> responseObserver) {
+    Mono.just(request)
+        .map(io.dapr.components.domain.state.DeleteRequest::new) //Convert to local domain
+        .flatMap(stateStore::delete)
+        // Response is functionally and structurally equivalent to Empty, nothing to fill.
+        .map(response -> State.DeleteResponse.getDefaultInstance())
+        .subscribe(responseObserver::onNext, responseObserver::onError, responseObserver::onCompleted);
+  }
+
+  @Override
+  public void bulkDelete(final BulkDeleteRequest request,
+                         final StreamObserver<State.BulkDeleteResponse> responseObserver) {
+    Flux.fromIterable(request.getItemsList())
+        .map(io.dapr.components.domain.state.DeleteRequest::new) // Convert to local domain/model
+        .flatMap(stateStore::delete)
+        .then() // convert this Flux to a Mono
+        .map(response -> State.BulkDeleteResponse.getDefaultInstance())
+        .subscribe(responseObserver::onNext, responseObserver::onError, responseObserver::onCompleted);
+  }
+
+  @Override
+  public void get(final GetRequest request, final StreamObserver<State.GetResponse> responseObserver) {
+    Mono.just(request)
+        .map(io.dapr.components.domain.state.GetRequest::new) // Convert to local domain/model
+        .flatMap(stateStore::get)
+        // If value is present, map it to an appropriate GetResponse object
+        .map(value -> State.GetResponse.newBuilder()
+          .setData(ByteString.copyFrom(value.data()))
+          .setEtag(Etag.newBuilder().setValue(value.etag()).build())
+          .build())
+        // otherwise return an empty response
+        .defaultIfEmpty(EMPTY_GET_RESPONSE)
+        .subscribe(responseObserver::onNext, responseObserver::onError, responseObserver::onCompleted);
+  }
+
+  @Override
+  public void bulkGet(final BulkGetRequest request,
+                      final StreamObserver<BulkGetResponse> responseObserver) {
+    Flux.fromIterable(request.getItemsList())
+        .map(io.dapr.components.domain.state.GetRequest::new) // Convert to local domain/model
+        // Let's convert all requested items into BulkStateItems objects.
+        .flatMap(requestedItem -> stateStore.get(requestedItem)
+            // If value is present, convert it to an appropriate BulkStateItem object
+            .map(value -> BulkStateItem.newBuilder()
+                .setKey(requestedItem.key())
+                .setData(ByteString.copyFrom(value.data()))
+                .setEtag(Etag.newBuilder()
+                    .setValue(value.etag())
+                    .build())
+                .setError(BulkGetError.NONE)
+                .build()
+            )
+            // otherwise return an empty BulkStateItem with corresponding error codes
+            .defaultIfEmpty(
+                BulkStateItem.newBuilder()
+                    .setKey(requestedItem.key())
+                    .setData(ByteString.EMPTY)
+                    .setEtag(EMPTY_ETAG)
+                    .setError(BulkGetError.KEY_DOES_NOT_EXIST)
+                    .build()
+            )
+        )
+        // Wrap them into a BulkGetResponse and send it away
+        .collectList()
+        .map(items -> BulkGetResponse.newBuilder()
+            .addAllItems(items)
+            .build())
+        .subscribe(responseObserver::onNext, responseObserver::onError, responseObserver::onCompleted);
+  }
+
+  @Override
+  public void set(final State.SetRequest request, final StreamObserver<State.SetResponse> responseObserver) {
+    Mono.just(request)
+        .map(SetRequest::new)  // Convert to local domain/model
+        .flatMap(stateStore::set)
+        // Response is functionally and structurally equivalent to Empty, nothing to fill.
+        .map(response -> State.SetResponse.getDefaultInstance())
+        .subscribe(responseObserver::onNext, responseObserver::onError, responseObserver::onCompleted);
+  }
+
+  @Override
+  public void bulkSet(final BulkSetRequest request, final StreamObserver<State.BulkSetResponse> responseObserver) {
+    // Do a forEach, calling stateStore.set for each item in the bulk request
+    Flux.fromIterable(request.getItemsList())
+        .map(SetRequest::new)  // Convert to local domain/model
+        .flatMap(stateStore::set)
+        .then() // convert this Flux to a Mono
+        // Response is functionally and structurally equivalent to Empty, nothing to fill.
+        .map(allRequestsWereSuccessful -> State.BulkSetResponse.getDefaultInstance())
+        .subscribe(responseObserver::onNext, responseObserver::onError, responseObserver::onCompleted);
+  }
+
+  @Override
+  public void ping(final ComponentProtos.PingRequest request,
+                   final StreamObserver<ComponentProtos.PingResponse> responseObserver) {
+    // Response is functionally and structurally equivalent to Empty, nothing to fill.
+    responseObserver.onNext(ComponentProtos.PingResponse.getDefaultInstance());
+    responseObserver.onCompleted();
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
 
     <modules>
         <module>components-java-sdk-autogen</module>
+        <module>components-java-sdk</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
This PR presents the base SDK model/POJOs for defining a state store pluggable component in Java along with the initial definition of an adaptor or wrapper between gRPC service definition and the StateStore interface defined in this PR.

Just like Dapr's [Java SDK], this SDK is built using [Project Reactor], which provides an asynchronous API for Java. This SDK relies heavily (abuse might be a better word) on [Project Reactor] functional programing paradigm adapt/couple the gRPC server model to the async StateStore service model define here. This means this code will look a bit more declarative than the usual and potentially missing some "try-catch" blocks. It isn't. Exception handling, invoking `onComplete` and yielding the return, this is all made by means of `Mono`/`Flux.subscribe` methods.

I am leaving this PR purposely limited to ease its review.

[Java SDK]: https://github.com/tmacam/dapr-java-sdk/ [Project Reactor]: https://projectreactor.io/

Signed-off-by: Tiago Alves Macambira <tmacam@burocrata.org>