### PR TITLE
Additional fixes for StateStore implementation.

### DIFF
--- a/components-java-sdk/src/main/java/io/dapr/components/aspects/AdvertisesFeatures.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/aspects/AdvertisesFeatures.java
@@ -15,8 +15,11 @@ package io.dapr.components.aspects;
 
 import reactor.core.publisher.Mono;
 
+import java.util.Collections;
 import java.util.List;
 
 public interface AdvertisesFeatures {
-  Mono<List<String>> getFeatures();
+  default Mono<List<String>> getFeatures() {
+    return Mono.just(Collections.emptyList());
+  }
 }

--- a/components-java-sdk/src/main/java/io/dapr/components/aspects/Pingable.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/aspects/Pingable.java
@@ -16,5 +16,7 @@ package io.dapr.components.aspects;
 import reactor.core.publisher.Mono;
 
 public interface Pingable {
-  Mono<Void> ping();
+  default Mono<Void> ping() {
+    return Mono.empty();
+  }
 }

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/Constants.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/Constants.java
@@ -11,14 +11,11 @@
  * limitations under the License.
  */
 
-package io.dapr.components.aspects;
+package io.dapr.components.domain.state;
 
-import reactor.core.publisher.Mono;
-
-import java.util.Map;
-
-public interface InitializableWithProperties {
-  default Mono<Void> init(Map<String, String> properties) {
-    return Mono.empty();
-  }
+public class Constants {
+  /**
+   * Default content type when one is not presented by the user.
+   */
+  public static final String DEFAULT_CONTENT_TYPE = "application/octet-stream";
 }

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/DeleteRequest.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/DeleteRequest.java
@@ -13,8 +13,6 @@
 
 package io.dapr.components.domain.state;
 
-import dapr.proto.components.v1.State;
-
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/GetResponse.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/GetResponse.java
@@ -13,9 +13,13 @@
 
 package io.dapr.components.domain.state;
 
+import com.google.protobuf.ByteString;
+
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
+
+import static io.dapr.components.domain.state.Constants.DEFAULT_CONTENT_TYPE;
 
 /**
  * Response for a StateStore#get request.
@@ -25,7 +29,26 @@ import java.util.Objects;
  * @param metadata Metadata related to the response.
  * @param contentType The response value contenttype
  */
-public record GetResponse(byte[] data, String etag, Map<String, String> metadata, String contentType) {
+public record GetResponse(ByteString data, String etag, Map<String, String> metadata, String contentType) {
+
+  /**
+   * Canonical Constructor.
+   *
+   * @param data The value of the GetRequest response.
+   * @param etag The etag of the associated key.
+   * @param metadata Metadata related to the response.
+   * @param contentType The response value contenttype
+   */
+  public GetResponse(final ByteString data, final String etag, final Map<String, String> metadata,
+                     final String contentType) {
+    // Java lacks a solution to "immutable byte arrays", so we wrap them up in a ByteString.
+    // FindBugs isn't really happy with this setup so we exclude EI_EXPOSE_REP* errors for this class
+    this.data = Objects.requireNonNull(data);
+    this.etag = Objects.requireNonNull(etag);
+    // All this constructor just so we can make this Map unmodifiable and this class immutable ;)
+    this.metadata = Collections.unmodifiableMap(Objects.requireNonNull(metadata));
+    this.contentType = Objects.requireNonNull(contentType);
+  }
 
   /**
    * Constructor.
@@ -35,11 +58,21 @@ public record GetResponse(byte[] data, String etag, Map<String, String> metadata
    * @param metadata Metadata related to the response.
    * @param contentType The response value contenttype
    */
-  public GetResponse(byte[] data, String etag, Map<String, String> metadata, String contentType) {
-    this.data = Objects.requireNonNull(data);
-    this.etag = Objects.requireNonNull(etag);
-    // All this constructor just so we can make this Map unmodifiable and this class immutable ;)
-    this.metadata = Collections.unmodifiableMap(Objects.requireNonNull(metadata));
-    this.contentType = Objects.requireNonNull(contentType);
+  public GetResponse(final byte[] data, final String etag, final Map<String, String> metadata,
+                     final String contentType) {
+    this(ByteString.copyFrom(Objects.requireNonNull(data)),
+        Objects.requireNonNull(etag),
+        Objects.requireNonNull(metadata),
+        Objects.requireNonNull(contentType));
+  }
+
+  /**
+   * Constructor with no metadata and using DEFAULT_CONTENT_TYPE for content type.
+   *
+   * @param data The value of the GetRequest response.
+   * @param etag The etag of the associated key.
+   */
+  public GetResponse(final byte[] data, final String etag) {
+    this(data, etag, Collections.emptyMap(), DEFAULT_CONTENT_TYPE);
   }
 }

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/SetRequest.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/SetRequest.java
@@ -13,6 +13,8 @@
 
 package io.dapr.components.domain.state;
 
+import com.google.protobuf.ByteString;
+
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
@@ -27,8 +29,29 @@ import java.util.Objects;
  * @param options The Set request options.
  * @param contentType The value contenttype.
  */
-public record SetRequest(String key, byte[] value, String etag, Map<String, String> metadata, StateOptions options,
+public record SetRequest(String key, ByteString value, String etag, Map<String, String> metadata, StateOptions options,
                          String contentType) {
+  /**
+   * Canonical Constructor.
+   *
+   * @param key The key that should be set.
+   * @param value Value is the desired content of the given key.
+   * @param etag The etag is used as a If-Match header, to allow certain levels of consistency.
+   * @param metadata The request metadata.
+   * @param options The Set request options.
+   * @param contentType The value contenttype.
+   */
+  public SetRequest(String key, ByteString value, String etag, Map<String, String> metadata, StateOptions options,
+                    String contentType) {
+    this.key = Objects.requireNonNull(key);
+    this.value = Objects.requireNonNull(value);
+    this.etag = Objects.requireNonNull(etag);
+    // All this constructor just so we can make this Map unmodifiable and this class immutable ;)
+    this.metadata = Collections.unmodifiableMap(Objects.requireNonNull(metadata));
+    this.options = Objects.requireNonNull(options);
+    this.contentType = Objects.requireNonNull(contentType);
+  }
+
   /**
    * Constructor.
    *
@@ -41,13 +64,13 @@ public record SetRequest(String key, byte[] value, String etag, Map<String, Stri
    */
   public SetRequest(String key, byte[] value, String etag, Map<String, String> metadata, StateOptions options,
                     String contentType) {
-    this.key = Objects.requireNonNull(key);
-    this.value = Objects.requireNonNull(value);
-    this.etag = Objects.requireNonNull(etag);
-    // All this constructor just so we can make this Map unmodifiable and this class immutable ;)
-    this.metadata = Collections.unmodifiableMap(Objects.requireNonNull(metadata));
-    this.options = Objects.requireNonNull(options);
-    this.contentType = Objects.requireNonNull(contentType);
+    this(Objects.requireNonNull(key),
+        ByteString.copyFrom(Objects.requireNonNull(value)),
+        Objects.requireNonNull(etag),
+        // All this constructor just so we can make this Map unmodifiable and this class immutable ;)
+        Objects.requireNonNull(metadata),
+        Objects.requireNonNull(options),
+        Objects.requireNonNull(contentType));
   }
 
   /**
@@ -57,7 +80,7 @@ public record SetRequest(String key, byte[] value, String etag, Map<String, Stri
    */
   public SetRequest(dapr.proto.components.v1.State.SetRequest other) {
     this(other.getKey(),
-        other.getValue().toByteArray(),
+        other.getValue(),
         other.getEtag().getValue(),
         other.getMetadataMap(),
         new StateOptions(other.getOptions()),

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/StateStore.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/StateStore.java
@@ -24,5 +24,5 @@ public interface StateStore extends InitializableWithProperties, AdvertisesFeatu
 
   Mono<Void> delete(DeleteRequest deleteRequest);
 
-  Mono<Void> set(SetRequest setRequeset);
+  Mono<Void> set(SetRequest setRequest);
 }

--- a/components-java-sdk/src/main/java/io/dapr/components/wrappers/StateStoreGrpcComponentWrapper.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/wrappers/StateStoreGrpcComponentWrapper.java
@@ -102,9 +102,13 @@ public class StateStoreGrpcComponentWrapper extends StateStoreGrpc.StateStoreImp
         .map(io.dapr.components.domain.state.GetRequest::new) // Convert to local domain/model
         .flatMap(stateStore::get)
         // If value is present, map it to an appropriate GetResponse object
-        .map(value -> State.GetResponse.newBuilder()
-          .setData(ByteString.copyFrom(value.data()))
-          .setEtag(Etag.newBuilder().setValue(value.etag()).build())
+        .map(response -> State.GetResponse.newBuilder()
+            .setData(response.data())
+            .setEtag(Etag.newBuilder()
+                .setValue(response.etag())
+                .build())
+            .putAllMetadata(response.metadata())
+            .setContentType(response.contentType())
           .build())
         // otherwise return an empty response
         .defaultIfEmpty(EMPTY_GET_RESPONSE)
@@ -121,7 +125,7 @@ public class StateStoreGrpcComponentWrapper extends StateStoreGrpc.StateStoreImp
             // If value is present, convert it to an appropriate BulkStateItem object
             .map(value -> BulkStateItem.newBuilder()
                 .setKey(requestedItem.key())
-                .setData(ByteString.copyFrom(value.data()))
+                .setData(value.data())
                 .setEtag(Etag.newBuilder()
                     .setValue(value.etag())
                     .build())

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <protobuf.version>3.17.3</protobuf.version>
         <springboot.version>2.3.5.RELEASE</springboot.version>
 
-        <spotbugs.version>4.0.0-RC1</spotbugs.version>
+        <spotbugs.version>4.7.3.0</spotbugs.version>
         <spotbugs.fail>true</spotbugs.fail>
 
         <!-- Project-wise language settings -->
@@ -117,18 +117,11 @@
             <plugin>
                 <groupId>com.github.spotbugs</groupId>
                 <artifactId>spotbugs-maven-plugin</artifactId>
-                <version>4.1.4</version>
-                <dependencies>
-                    <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
-                    <dependency>
-                        <groupId>com.github.spotbugs</groupId>
-                        <artifactId>spotbugs</artifactId>
-                        <version>${spotbugs.version}</version>
-                    </dependency>
-                </dependencies>
+                <version>${spotbugs.version}</version>
                 <configuration>
                     <failOnError>${spotbugs.fail}</failOnError>
                     <xmlOutput>true</xmlOutput>
+                    <excludeFilterFile>spotbugs-exclude.xml</excludeFilterFile>
                 </configuration>
                 <executions>
                     <execution>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter
+        xmlns="https://github.com/spotbugs/filter/3.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+    <Match>
+        <Or>
+            <!-- we are using ByteString as a immutable byte array. This is a false positive. -->
+            <Class name="io.dapr.components.domain.state.GetResponse" />
+            <Class name="io.dapr.components.domain.state.SetRequest" />
+
+            <!-- StateStore wrapper has to be stored internally  -->
+            <Class name="io.dapr.components.wrappers.StateStoreGrpcComponentWrapper" />
+        </Or>
+        <Or>
+            <Bug pattern="EI_EXPOSE_REP" />
+            <Bug pattern="EI_EXPOSE_REP2" />
+        </Or>
+
+    </Match>
+</FindBugsFilter>


### PR DESCRIPTION
* Updates SpotBugs version to address incompatibility with Java 17, which was causing build failures.
* Addresses issues identified by SpotBugs. * Changes internal `char[]` to Protocol Buffer's ByteString. While SpotBugs still complains, this is a safe representation of immutable byte arrays. * Registers affected classes in SpotBugs exclusion list.
* Provides default implementations for `Pingable`, `AdvertisesFeatures` and `InitializableWithProperties`, effectively turning them into optional interfaces.
* Adds some constructors to domain classes to ease developer usage.

Signed-off-by: Tiago Alves Macambira <tmacam@burocrata.org>