### PR TITLE
Transactions and Query domain classes.

### DIFF
--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/DeleteRequest.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/DeleteRequest.java
@@ -24,8 +24,14 @@ import java.util.Objects;
  * @param etag The etag is used as a If-Match header, to allow certain levels of consistency.
  * @param metadata The request metadata.
  * @param options Consistency and concurrency options.
+ *
+ * {@see TransactionableOperation}
  */
-public record DeleteRequest(String key, String etag, Map<String, String> metadata, StateOptions options) {
+public record DeleteRequest(
+    String key,
+    String etag,
+    Map<String, String> metadata,
+    StateOptions options) implements TransactionableOperation {
 
   /**
    * Constructor.
@@ -39,7 +45,7 @@ public record DeleteRequest(String key, String etag, Map<String, String> metadat
     this.key = Objects.requireNonNull(key);
     this.etag = Objects.requireNonNull(etag);
     // All this constructor just so we can make this Map unmodifiable and this class immutable ;)
-    this.metadata = Collections.unmodifiableMap(Objects.requireNonNull(metadata));
+    this.metadata = Map.copyOf(Objects.requireNonNull(metadata));
     this.options = Objects.requireNonNull(options);
   }
 

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/GetRequest.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/GetRequest.java
@@ -13,6 +13,8 @@
 
 package io.dapr.components.domain.state;
 
+import io.dapr.components.domain.state.options.StateConsistency;
+
 import java.util.Map;
 import java.util.Objects;
 
@@ -23,7 +25,7 @@ import java.util.Objects;
  * @param metadata Request associated metadata.
  * @param consistency The get consistency level.
  */
-public record GetRequest(String key, Map<String, String> metadata, StateOptions.StateConsistency consistency) {
+public record GetRequest(String key, Map<String, String> metadata, StateConsistency consistency) {
 
   /**
    * Constructor.
@@ -32,7 +34,7 @@ public record GetRequest(String key, Map<String, String> metadata, StateOptions.
    * @param metadata Request associated metadata.
    * @param consistency The get consistency level.
    */
-  public GetRequest(String key, Map<String, String> metadata, StateOptions.StateConsistency consistency) {
+  public GetRequest(String key, Map<String, String> metadata, StateConsistency consistency) {
     this.key = Objects.requireNonNull(key);
     this.metadata = Map.copyOf(Objects.requireNonNull(metadata));
     this.consistency = Objects.requireNonNull(consistency);
@@ -46,6 +48,6 @@ public record GetRequest(String key, Map<String, String> metadata, StateOptions.
   public GetRequest(dapr.proto.components.v1.State.GetRequest other) {
     this(other.getKey(),
         other.getMetadataMap(),
-        StateOptions.StateConsistency.of(other.getConsistency()));
+        StateConsistency.fromValue(other.getConsistency()));
   }
 }

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/GetRequest.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/GetRequest.java
@@ -13,7 +13,6 @@
 
 package io.dapr.components.domain.state;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
@@ -35,7 +34,7 @@ public record GetRequest(String key, Map<String, String> metadata, StateOptions.
    */
   public GetRequest(String key, Map<String, String> metadata, StateOptions.StateConsistency consistency) {
     this.key = Objects.requireNonNull(key);
-    this.metadata = Collections.unmodifiableMap(Objects.requireNonNull(metadata));
+    this.metadata = Map.copyOf(Objects.requireNonNull(metadata));
     this.consistency = Objects.requireNonNull(consistency);
   }
 

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/GetResponse.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/GetResponse.java
@@ -46,7 +46,7 @@ public record GetResponse(ByteString data, String etag, Map<String, String> meta
     this.data = Objects.requireNonNull(data);
     this.etag = Objects.requireNonNull(etag);
     // All this constructor just so we can make this Map unmodifiable and this class immutable ;)
-    this.metadata = Collections.unmodifiableMap(Objects.requireNonNull(metadata));
+    this.metadata = Map.copyOf(Objects.requireNonNull(metadata));
     this.contentType = Objects.requireNonNull(contentType);
   }
 

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/Pagination.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/Pagination.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.domain.state;
+
+/**
+ * Representation of pagination parameters.
+ *
+ * @param limit Maximum of results that should be returned.
+ * @param token The pagination token.
+ */
+public record Pagination(int limit, String token) {
+}

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/QueriableStateStore.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/QueriableStateStore.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.domain.state;
+
+import dapr.proto.components.v1.State;
+import reactor.core.publisher.Mono;
+
+/**
+ * QueriableStateStore service provides a gRPC interface for querier state store
+ * components. It was designed to embed query features to the StateStore Service
+ * as a complementary service.
+ */
+public interface QueriableStateStore  {
+  /**
+   * Query performs a query request on the statestore..
+   *
+   * @param request the query.
+   * @return A reponse encapsulated in a QueryReponse object.
+   */
+  Mono<QueryResponse> query(QueryRequest request);
+}

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/Query.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/Query.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.domain.state;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Representation of a Query.
+ *
+ * @param filter Filters that should be applied.
+ * @param sort The sort order.
+ * @param pagination The query pagination params.
+ */
+public record Query(Map<String, Object> filter, List<Sorting> sort, @Nullable Pagination pagination) {
+
+  /**
+   * Canonical constructor.
+   *
+   * @param filter Filters that should be applied.
+   * @param sort The sort order.
+   * @param pagination The query pagination params.
+   */
+  public Query(Map<String, Object> filter, List<Sorting> sort, Pagination pagination) {
+    this.filter = Map.copyOf(Objects.requireNonNull(filter));
+    this.sort = List.copyOf(Objects.requireNonNull(sort));
+    this.pagination = pagination;
+  }
+}

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/QueryItem.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/QueryItem.java
@@ -25,4 +25,16 @@ import com.google.protobuf.ByteString;
  * @param contentType  The returned content-type.
  */
 public record QueryItem(String key, ByteString data, String etag, String error, String contentType) {
+  /**
+   * Alternative constructor.
+   *
+   * @param key The returned item Key.
+   * @param data The returned item Data.
+   * @param etag The returned item ETag.
+   * @param error The returned error string.
+   * @param contentType  The returned content-type.
+   */
+  public QueryItem(String key, final byte[] data, String etag, String error, String contentType) {
+    this(key, ByteString.copyFrom(data), etag, error, contentType);
+  }
 }

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/QueryItem.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/QueryItem.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.domain.state;
+
+import com.google.protobuf.ByteString;
+
+/**
+ * QueryItem is an object representing a single entry in query results.
+ *
+ * @param key The returned item Key.
+ * @param data The returned item Data.
+ * @param etag The returned item ETag.
+ * @param error The returned error string.
+ * @param contentType  The returned content-type.
+ */
+public record QueryItem(String key, ByteString data, String etag, String error, String contentType) {
+}

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/QueryRequest.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/QueryRequest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.domain.state;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * QueryRequest is for querying state store.
+ *
+ * @param query The query to be performed.
+ * @param metadata Request associated metadata.
+ */
+public record QueryRequest(Query query, Map<String,String> metadata) {
+  /**
+   * Canonical constructor.
+   *
+   * @param query The query to be performed.
+   * @param metadata Request associated metadata.
+   */
+  public QueryRequest(final Query query, final Map<String, String> metadata) {
+    this.query = Objects.requireNonNull(query);
+    this.metadata = Objects.requireNonNull(metadata);
+  }
+}

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/QueryResponse.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/QueryResponse.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.domain.state;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * QueryResponse is the query response.
+ *
+ * @param items The query response items.
+ * @param token The response token.
+ * @param metadata Response associated metadata.
+ */
+public record QueryResponse(List<QueryItem> items, String token, Map<String, String> metadata) {
+  /**
+   * Canonical constructor.
+   *
+   * @param items The query response items.
+   * @param token The response token.
+   * @param metadata Response associated metadata.
+   */
+  public QueryResponse(List<QueryItem> items, String token, Map<String, String> metadata) {
+    this.items = List.copyOf(Objects.requireNonNull(items));
+    this.token = Objects.requireNonNull(token);
+    this.metadata = Map.copyOf(Objects.requireNonNull(metadata));
+  }
+}

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/QueryResponse.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/QueryResponse.java
@@ -24,7 +24,7 @@ import java.util.Objects;
  * @param token The response token.
  * @param metadata Response associated metadata.
  */
-public record QueryResponse(List<QueryItem> items, String token, Map<String, String> metadata) {
+public record QueryResponse(List<QueryResponseItem> items, String token, Map<String, String> metadata) {
   /**
    * Canonical constructor.
    *
@@ -32,7 +32,7 @@ public record QueryResponse(List<QueryItem> items, String token, Map<String, Str
    * @param token The response token.
    * @param metadata Response associated metadata.
    */
-  public QueryResponse(List<QueryItem> items, String token, Map<String, String> metadata) {
+  public QueryResponse(List<QueryResponseItem> items, String token, Map<String, String> metadata) {
     this.items = List.copyOf(Objects.requireNonNull(items));
     this.token = Objects.requireNonNull(token);
     this.metadata = Map.copyOf(Objects.requireNonNull(metadata));

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/QueryResponseItem.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/QueryResponseItem.java
@@ -24,7 +24,7 @@ import com.google.protobuf.ByteString;
  * @param error The returned error string.
  * @param contentType  The returned content-type.
  */
-public record QueryItem(String key, ByteString data, String etag, String error, String contentType) {
+public record QueryResponseItem(String key, ByteString data, String etag, String error, String contentType) {
   /**
    * Alternative constructor.
    *
@@ -34,7 +34,7 @@ public record QueryItem(String key, ByteString data, String etag, String error, 
    * @param error The returned error string.
    * @param contentType  The returned content-type.
    */
-  public QueryItem(String key, final byte[] data, String etag, String error, String contentType) {
+  public QueryResponseItem(String key, final byte[] data, String etag, String error, String contentType) {
     this(key, ByteString.copyFrom(data), etag, error, contentType);
   }
 }

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/SetRequest.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/SetRequest.java
@@ -15,7 +15,6 @@ package io.dapr.components.domain.state;
 
 import com.google.protobuf.ByteString;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
@@ -28,9 +27,16 @@ import java.util.Objects;
  * @param metadata The request metadata.
  * @param options The Set request options.
  * @param contentType The value contenttype.
+ *
+ * {@see TransactionableOperation}
  */
-public record SetRequest(String key, ByteString value, String etag, Map<String, String> metadata, StateOptions options,
-                         String contentType) {
+public record SetRequest(
+    String key,
+    ByteString value,
+    String etag,
+    Map<String, String> metadata,
+    StateOptions options,
+    String contentType) implements TransactionableOperation {
   /**
    * Canonical Constructor.
    *
@@ -47,7 +53,7 @@ public record SetRequest(String key, ByteString value, String etag, Map<String, 
     this.value = Objects.requireNonNull(value);
     this.etag = Objects.requireNonNull(etag);
     // All this constructor just so we can make this Map unmodifiable and this class immutable ;)
-    this.metadata = Collections.unmodifiableMap(Objects.requireNonNull(metadata));
+    this.metadata = Map.copyOf(Objects.requireNonNull(metadata));
     this.options = Objects.requireNonNull(options);
     this.contentType = Objects.requireNonNull(contentType);
   }

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/Sorting.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/Sorting.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.domain.state;
+
+import dapr.proto.components.v1.State;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Describes a sorting order to be performed by a Query.
+ *
+ * @param key The key that should be used for sorting.
+ * @param order The order that should be used.
+ */
+public record Sorting(String key, Order order) {
+
+  enum Order {
+    ASC(dapr.proto.components.v1.State.Sorting.Order.ASC),
+    DESC(dapr.proto.components.v1.State.Sorting.Order.DESC);
+
+    private final dapr.proto.components.v1.State.Sorting.Order equivalent;
+
+    Order(dapr.proto.components.v1.State.Sorting.Order equivalent) {
+      this.equivalent = equivalent;
+    }
+
+    // Convert Protocol Buffer model to this SDK internal Model
+    static final Map<dapr.proto.components.v1.State.Sorting.Order, Sorting.Order> toSdkModel =
+        Arrays.stream(Sorting.Order.values())
+            .collect(Collectors.toMap(Sorting.Order::getValue, Function.identity()));
+
+    public State.Sorting.Order getValue() {
+      return equivalent;
+    }
+
+    public static Sorting.Order of(dapr.proto.components.v1.State.Sorting.Order value) {
+      return toSdkModel.get(value);
+    }
+  }
+}

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/Sorting.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/Sorting.java
@@ -13,12 +13,7 @@
 
 package io.dapr.components.domain.state;
 
-import dapr.proto.components.v1.State;
-
-import java.util.Arrays;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+import io.dapr.components.domain.state.options.Order;
 
 /**
  * Describes a sorting order to be performed by a Query.
@@ -28,27 +23,4 @@ import java.util.stream.Collectors;
  */
 public record Sorting(String key, Order order) {
 
-  enum Order {
-    ASC(dapr.proto.components.v1.State.Sorting.Order.ASC),
-    DESC(dapr.proto.components.v1.State.Sorting.Order.DESC);
-
-    private final dapr.proto.components.v1.State.Sorting.Order equivalent;
-
-    Order(dapr.proto.components.v1.State.Sorting.Order equivalent) {
-      this.equivalent = equivalent;
-    }
-
-    // Convert Protocol Buffer model to this SDK internal Model
-    static final Map<dapr.proto.components.v1.State.Sorting.Order, Sorting.Order> toSdkModel =
-        Arrays.stream(Sorting.Order.values())
-            .collect(Collectors.toMap(Sorting.Order::getValue, Function.identity()));
-
-    public State.Sorting.Order getValue() {
-      return equivalent;
-    }
-
-    public static Sorting.Order of(dapr.proto.components.v1.State.Sorting.Order value) {
-      return toSdkModel.get(value);
-    }
-  }
 }

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/StateOptions.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/StateOptions.java
@@ -14,12 +14,10 @@
 package io.dapr.components.domain.state;
 
 import dapr.proto.components.v1.State;
+import io.dapr.components.domain.state.options.StateConcurrency;
+import io.dapr.components.domain.state.options.StateConsistency;
 
-import java.util.Arrays;
-import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 public record StateOptions(StateConcurrency concurrency, StateConsistency consistency) {
 
@@ -29,66 +27,7 @@ public record StateOptions(StateConcurrency concurrency, StateConsistency consis
   }
 
   public StateOptions(State.StateOptions other) {
-    this(StateConcurrency.of(other.getConcurrency()), StateConsistency.of(other.getConsistency()));
-  }
-
-  /**
-   * Enum describing the supported concurrency for state.
-   */
-  public enum StateConcurrency {
-    UNSPECIFIED(State.StateOptions.StateConcurrency.CONCURRENCY_UNSPECIFIED),
-
-    FIRST_WRITE(State.StateOptions.StateConcurrency.CONCURRENCY_FIRST_WRITE),
-
-    LAST_WRITE(State.StateOptions.StateConcurrency.CONCURRENCY_LAST_WRITE);
-
-    // The gRPC equivalent for this enum
-    private final State.StateOptions.StateConcurrency equivalent;
-
-    // Convert Protocol Buffer model to this SDK internal Model
-    static final Map<State.StateOptions.StateConcurrency, StateConcurrency> toSdkModel =
-        Arrays.stream(StateConcurrency.values())
-            .collect(Collectors.toMap(StateConcurrency::getValue, Function.identity()));
-
-
-    StateConcurrency(State.StateOptions.StateConcurrency value) {
-      this.equivalent = value;
-    }
-
-    public State.StateOptions.StateConcurrency getValue() {
-      return this.equivalent;
-    }
-
-    public static StateConcurrency of(State.StateOptions.StateConcurrency value) {
-      return toSdkModel.get(value);
-    }
-  }
-
-  /**
-   * Enum describing the supported consistency for state.
-   */
-  enum StateConsistency {
-    UNSPECIFIED(State.StateOptions.StateConsistency.CONSISTENCY_UNSPECIFIED),
-    EVENTUAL(State.StateOptions.StateConsistency.CONSISTENCY_EVENTUAL),
-    STRONG(State.StateOptions.StateConsistency.CONSISTENCY_STRONG);
-
-    private final State.StateOptions.StateConsistency equivalent;
-
-    // Convert Protocol Buffer model to this SDK internal Model
-    static final Map<State.StateOptions.StateConsistency, StateConsistency> toSdkModel =
-        Arrays.stream(StateConsistency.values())
-            .collect(Collectors.toMap(StateConsistency::getValue, Function.identity()));
-
-    StateConsistency(State.StateOptions.StateConsistency value) {
-      this.equivalent = value;
-    }
-
-    public State.StateOptions.StateConsistency getValue() {
-      return this.equivalent;
-    }
-
-    public static StateConsistency of(State.StateOptions.StateConsistency value) {
-      return toSdkModel.get(value);
-    }
+    this(StateConcurrency.fromValue(other.getConcurrency()),
+        StateConsistency.fromValue(other.getConsistency()));
   }
 }

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/TransactionableOperation.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/TransactionableOperation.java
@@ -18,6 +18,14 @@ package io.dapr.components.domain.state;
  *
  * <p>This interface is being used as a type-safe alternative to representing the enum/oneof
  * used by {@link dapr.proto.components.v1.State.TransactionalStateOperation}</p>
+ * <p>Notice that there are only 2 operations that can be used in a
+ * {@link TransactionalStateRequest}:
+ * <ul>
+ *   <li>{@link DeleteRequest}</li>
+ *   <li>{@link SetRequest}</li>
+ * </ul>
+ * </p>
+ * <p>Besides those two operations above, no other operation should implement this interface.</p>
  */
 public interface TransactionableOperation {
 }

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/TransactionableOperation.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/TransactionableOperation.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.domain.state;
+
+/**
+ * This interface act as a marker for operations that can be used with Transactions.
+ *
+ * <p>This interface is being used as a type-safe alternative to representing the enum/oneof
+ * used by {@link dapr.proto.components.v1.State.TransactionalStateOperation}</p>
+ */
+public interface TransactionableOperation {
+}

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/TransactionalStateRequest.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/TransactionalStateRequest.java
@@ -16,6 +16,7 @@ package io.dapr.components.domain.state;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Consumer;
 
 public record TransactionalStateRequest(List<TransactionableOperation> operations, Map<String, String> metadata) {
 
@@ -23,5 +24,27 @@ public record TransactionalStateRequest(List<TransactionableOperation> operation
                                    final Map<String, String> metadata) {
     this.operations = List.copyOf(Objects.requireNonNull(operations));
     this.metadata = Map.copyOf(Objects.requireNonNull(metadata));
+  }
+
+  /**
+   * Iterates over each item in the operations list invoking the appropriate visitor
+   * in the same order those operations are found in the list.
+   *
+   * @param deleteVisitor Visitor that will be invoked for delete requests in the list.
+   * @param setVisitor  Visitor that will be invoked for delete requests in the operations
+   *                    list.
+   */
+  public void forEachOperation(Consumer<DeleteRequest> deleteVisitor,
+                               Consumer<SetRequest> setVisitor) {
+    for (var operation : this.operations()) {
+      if (operation instanceof DeleteRequest deleteRequest) {
+        deleteVisitor.accept(deleteRequest);
+      } else if (operation instanceof SetRequest setRequest) {
+        setVisitor.accept(setRequest);
+      } else {
+        throw new UnsupportedOperationException("The provided operation of type "
+            + operation.getClass().toString() + " is not a valid TransactionableOperation");
+      }
+    }
   }
 }

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/TransactionalStateRequest.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/TransactionalStateRequest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.domain.state;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public record TransactionalStateRequest(List<TransactionableOperation> operations, Map<String, String> metadata) {
+
+  public TransactionalStateRequest(final List<TransactionableOperation> operations,
+                                   final Map<String, String> metadata) {
+    this.operations = List.copyOf(Objects.requireNonNull(operations));
+    this.metadata = Map.copyOf(Objects.requireNonNull(metadata));
+  }
+}

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/TransactionalStateStore.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/TransactionalStateStore.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.domain.state;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * TransactionalStateStore service provides a gRPC interface for transactional
+ * state store components. It was designed to embed transactional features to
+ * the StateStore Service as a complementary service.
+ */
+public interface TransactionalStateStore {
+  /**
+   * Transact executes multiples operation in a transactional environment.
+   *
+   * @param request The transactional request.
+   * @return A Mono representing the success (or failure) of the operation.
+   */
+  Mono<Void> transact(TransactionalStateRequest request);
+}

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/options/Order.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/options/Order.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.domain.state.options;
+
+import dapr.proto.components.v1.State;
+import io.dapr.components.domain.state.Sorting;
+
+public enum Order {
+  ASC,
+  DESC,
+  UNRECOGNIZED;
+
+  /**
+   * Get the gRPC equivalent for this enum.
+   *
+   * @return The gRPC equivalent.
+   */
+  public State.Sorting.Order getValue() {
+    return getValue(this);
+  }
+
+  /**
+   * Get the gRPC equivalent of an enum.
+   * @param sdkEnum the SDK enum to convert.
+   * @return The gRPC equivalent
+   */
+  public static State.Sorting.Order getValue(Order sdkEnum) {
+    return switch (sdkEnum) {
+      case ASC -> State.Sorting.Order.ASC;
+      case DESC -> State.Sorting.Order.DESC;
+      case UNRECOGNIZED -> State.Sorting.Order.UNRECOGNIZED;
+    };
+  }
+
+  /**
+   * Convert a gRPC Enum to the SDK's equivalent.
+   * @param value the gRPC enum
+   * @return the equivalent SDK enum.
+   */
+  public static Order fromValue(State.Sorting.Order value) {
+    return switch (value) {
+      case ASC -> Order.ASC;
+      case DESC -> Order.DESC;
+      case UNRECOGNIZED -> Order.UNRECOGNIZED;
+    };
+  }
+}

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/options/StateConcurrency.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/options/StateConcurrency.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.domain.state.options;
+
+import dapr.proto.components.v1.State;
+import io.dapr.components.domain.state.StateOptions;
+
+/**
+ * Enum describing the supported concurrency for state.
+ */
+public enum StateConcurrency {
+  UNSPECIFIED,
+  FIRST_WRITE,
+  LAST_WRITE,
+  UNRECOGNIZED;
+
+  /**
+   * Get the gRPC equivalent for this enum.
+   *
+   * @return The gRPC equivalent.
+   */
+  public State.StateOptions.StateConcurrency getValue() {
+    return getValue(this);
+  }
+
+  /**
+   * Get the gRPC equivalent of an enum.
+   * @param sdkEnum the SDK enum to convert.
+   * @return The gRPC equivalent
+   */
+  public State.StateOptions.StateConcurrency getValue(StateConcurrency sdkEnum) {
+    return switch (sdkEnum) {
+      case UNSPECIFIED -> State.StateOptions.StateConcurrency.CONCURRENCY_UNSPECIFIED;
+      case FIRST_WRITE -> State.StateOptions.StateConcurrency.CONCURRENCY_FIRST_WRITE;
+      case LAST_WRITE -> State.StateOptions.StateConcurrency.CONCURRENCY_LAST_WRITE;
+      case UNRECOGNIZED -> State.StateOptions.StateConcurrency.UNRECOGNIZED;
+    };
+  }
+
+  /**
+   * Convert a gRPC Enum to the SDK's equivalent.
+   * @param value the gRPC enum
+   * @return the equivalent SDK enum.
+   */
+  public static StateConcurrency fromValue(State.StateOptions.StateConcurrency value) {
+    return switch (value) {
+      case CONCURRENCY_UNSPECIFIED -> UNSPECIFIED;
+      case CONCURRENCY_FIRST_WRITE -> FIRST_WRITE;
+      case CONCURRENCY_LAST_WRITE -> LAST_WRITE;
+      case UNRECOGNIZED -> UNRECOGNIZED;
+    };
+  }
+}

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/state/options/StateConsistency.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/state/options/StateConsistency.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.domain.state.options;
+
+import dapr.proto.components.v1.State;
+import io.dapr.components.domain.state.StateOptions;
+
+/**
+ * Enum describing the supported consistency for state.
+ */
+public enum StateConsistency {
+  UNSPECIFIED,
+  EVENTUAL,
+  STRONG,
+  UNRECOGNIZED;
+
+  // Convert Protocol Buffer model to this SDK internal Model
+  /**
+   * Get the gRPC equivalent for this enum.
+   *
+   * @return The gRPC equivalent.
+   */
+  public State.StateOptions.StateConsistency getValue() {
+    return getValue(this);
+  }
+
+  /**
+   * Get the gRPC equivalent of an enum.
+   * @param sdkEnum the SDK enum to convert.
+   * @return The gRPC equivalent
+   */
+  public static State.StateOptions.StateConsistency getValue(StateConsistency sdkEnum) {
+    return switch (sdkEnum) {
+      case UNSPECIFIED -> State.StateOptions.StateConsistency.CONSISTENCY_UNSPECIFIED;
+      case EVENTUAL -> State.StateOptions.StateConsistency.CONSISTENCY_EVENTUAL;
+      case STRONG -> State.StateOptions.StateConsistency.CONSISTENCY_STRONG;
+      case UNRECOGNIZED -> State.StateOptions.StateConsistency.UNRECOGNIZED;
+    };
+  }
+
+  /**
+   * Convert a gRPC Enum to the SDK's equivalent.
+   * @param value the gRPC enum
+   * @return the equivalent SDK enum.
+   */
+  public static StateConsistency fromValue(State.StateOptions.StateConsistency value) {
+    return switch (value) {
+      case CONSISTENCY_UNSPECIFIED -> UNSPECIFIED;
+      case CONSISTENCY_EVENTUAL -> EVENTUAL;
+      case CONSISTENCY_STRONG -> STRONG;
+      case UNRECOGNIZED -> UNRECOGNIZED;
+    };
+  }
+}

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -5,17 +5,26 @@
         xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
     <Match>
         <Or>
-            <!-- we are using ByteString as a immutable byte array. This is a false positive. -->
+            <!-- We are using Map.copyOf and Lists.copyOf to create immutable copies of lists and maps. Sorry
+                 SpotBugs but you are missing the point here.
+                 See https://github.com/spotbugs/spotbugs/pull/2141
+             -->
             <Class name="io.dapr.components.domain.state.GetResponse" />
             <Class name="io.dapr.components.domain.state.SetRequest" />
+            <Class name="io.dapr.components.domain.state.QueryRequest" />
+            <Class name="io.dapr.components.domain.state.TransactionalStateRequest" />
 
             <!-- StateStore wrapper has to be stored internally  -->
             <Class name="io.dapr.components.wrappers.StateStoreGrpcComponentWrapper" />
         </Or>
         <Or>
-            <Bug pattern="EI_EXPOSE_REP" />
-            <Bug pattern="EI_EXPOSE_REP2" />
+            <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
         </Or>
+    </Match>
 
+    <Match>
+        <!-- we are using ByteString as am immutable byte array. This is a false positive. -->
+        <Field type="com.google.protobuf.ByteString"/>
+        <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2" />
     </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Extends the State Store domain with classes and interfaces for Queries and Transactions.

* Replaces uses of `Collections.unmodifiableMap` and `Collections.unmodifiableList`  with `Map.copyOf` and `List.of` since the latter are both shorter and [copies over collections to immutable data structures](https://docs.oracle.com/javase/9/core/creating-immutable-lists-sets-and-maps.htm)