### PR TITLE
Add GH issue and pull request templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Report a bug in Dapr's Java Pluggable Components SDK
+title: ''
+labels: kind/bug
+assignees: ''
+
+---
+## Expected Behavior
+
+<!-- Briefly describe what you expect to happen -->
+
+
+## Actual Behavior
+
+<!-- Briefly describe what is actually happening -->
+
+
+## Steps to Reproduce the Problem
+
+<!-- How can a maintainer reproduce this issue (be detailed) -->
+
+## Release Note
+
+<!-- How should the fix for this issue be communicated in our release notes? It can be populated later. -->
+<!-- Keep it as a single line. Examples: -->
+
+<!-- RELEASE NOTE: **ADD** New feature in Dapr. -->
+<!-- RELEASE NOTE: **FIX** Bug in runtime. -->
+<!-- RELEASE NOTE: **UPDATE** Runtime dependency. -->
+
+RELEASE NOTE:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature Request
+about: Create a Feature Request for Dapr's Java Pluggable Components SDK
+title: ''
+labels: kind/enhancement
+assignees: ''
+
+---
+## Describe the feature
+
+## Release Note
+<!-- How should this new feature be announced in our release notes? It can be populated later. -->
+<!-- Keep it as a single line. Examples: -->
+
+<!-- RELEASE NOTE: **ADD** New feature in Dapr. -->
+<!-- RELEASE NOTE: **FIX** Bug in runtime. -->
+<!-- RELEASE NOTE: **UPDATE** Runtime dependency. -->
+
+RELEASE NOTE:

--- a/.github/ISSUE_TEMPLATE/proposal.md
+++ b/.github/ISSUE_TEMPLATE/proposal.md
@@ -1,0 +1,9 @@
+---
+name: Proposal
+about: Create a proposal for Dapr's Java Pluggable Components SDK
+title: ''
+labels: kind/proposal
+assignees: ''
+
+---
+## Describe the proposal

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,9 @@
+---
+name: Question
+about: Ask a question about the Dapr's Java Pluggable Components SDK
+title: ''
+labels: kind/question
+assignees: ''
+
+---
+## Ask your question here

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+# Description
+
+_Please explain the changes you've made_
+
+## Issue reference
+
+We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
+
+Please reference the issue this PR will close: #_[issue number]_
+
+## Checklist
+
+Please make sure you've completed the relevant tasks for this PR, out of the following list:
+
+* [ ] Code compiles correctly
+* [ ] Created/updated tests
+* [ ] Extended the documentation


### PR DESCRIPTION
Add the CONTRIBUTING and GitHub issue templates to the repo, adapted from those in dapr/java-sdk and dapr-sandbox/components-dotnet-sdk.

