### PR TITLE
Base model/domain classes for PubSub API.

### DIFF
--- a/components-java-sdk-autogen/pom.xml
+++ b/components-java-sdk-autogen/pom.xml
@@ -83,6 +83,19 @@
                             <outputDirectory>${protobuf.input.directory.components}</outputDirectory>
                         </configuration>
                     </execution>
+                    <!-- components/pubsub -->
+                    <execution>
+                        <id>getComponentsPubSubProto</id>
+                        <!-- the wget goal actually binds itself to this phase by default -->
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>${dapr.proto.baseurl}/components/v1/pubsub.proto</url>
+                            <outputDirectory>${protobuf.input.directory.components}</outputDirectory>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <!-- Generate sources from downloaded protos -->

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/pubsub/PubSub.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/pubsub/PubSub.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.domain.pubsub;
+
+import io.dapr.components.aspects.AdvertisesFeatures;
+import io.dapr.components.aspects.InitializableWithProperties;
+import io.dapr.components.aspects.Pingable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Represents a PubSub components.
+ */
+public interface PubSub extends InitializableWithProperties, AdvertisesFeatures, Pingable {
+
+  /** Publish publishes a new message for the given topicName.
+   *
+   * @param request A request to publish something to a PubSub.
+   * @return An empty Mono representing success or error.
+   */
+  Mono<Void> publish(PublishRequest request);
+
+  /**
+   * Establishes a stream with the server (PubSub component), which sends
+   * messages down to the client (daprd). The client streams acknowledgements
+   * back to the server. The server will close the stream and return the status
+   * on any error. In case of closed connection, the client should re-establish
+   * the stream. The first message MUST contain a `topicName` attribute on it that
+   * should be used for the entire streaming pull.
+   *
+   * @param request A series of PullMessageRequest. Notice that the very first message in that stream is special in
+   *                that it <b>MUST</b> contain a {@code topicName} attribute on it that should be used for the entire
+   *                streaming pull.
+   * @return A Flux with all the acknowledgements we are sending to a server.
+   */
+  Flux<PullMessagesResponse> pullMessages(Flux<PullMessagesRequest> request);
+
+}

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/pubsub/PubSub.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/pubsub/PubSub.java
@@ -39,9 +39,10 @@ public interface PubSub extends InitializableWithProperties, AdvertisesFeatures,
    * the stream. The first message MUST contain a `topicName` attribute on it that
    * should be used for the entire streaming pull.
    *
-   * @param request A series of PullMessageRequest. Notice that the very first message in that stream is special in
-   *                that it <b>MUST</b> contain a {@code topicName} attribute on it that should be used for the entire
-   *                streaming pull.
+   * @param request A series of PullMessageRequest. Notice that the very first message in that stream
+   *               <b>MUST</b> contain a {@code topicName} attribute on it that should be used for
+   *               the entire streaming pull. Next messages sent to this flux will be used to
+   *                acknowledge received messages.
    * @return A Flux with all the acknowledgements we are sending to a server.
    */
   Flux<PullMessagesResponse> pullMessages(Flux<PullMessagesRequest> request);

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/pubsub/PublishRequest.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/pubsub/PublishRequest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.domain.pubsub;
+
+import com.google.protobuf.ByteString;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Represents a request to publish data to a given PubSub and topicName.
+ *
+ * @param data The data to be published.
+ * @param pubSubName The pubsub name.
+ * @param topic The publishing topicName.
+ * @param metadata Message metadata.
+ * @param contentType The data content type.
+ */
+public record PublishRequest(ByteString data, String pubSubName, String topic, Map<String, String> metadata,
+                             String contentType) {
+  /**
+   * Canonical constructor.
+   *
+   * @param data The data to be published.
+   * @param pubSubName The pubsub name.
+   * @param topic The publishing topicName.
+   * @param metadata Message metadata.
+   * @param contentType The data content type.
+   */
+  public PublishRequest(ByteString data, String pubSubName, String topic, Map<String, String> metadata,
+                        String contentType) {
+    this.data = Objects.requireNonNull(data);
+    this.pubSubName = Objects.requireNonNull(pubSubName);
+    this.topic = Objects.requireNonNull(topic);
+    // All this constructor just so we can make this Map unmodifiable and this class immutable ;)
+    this.metadata = Map.copyOf(Objects.requireNonNull(metadata));
+    this.contentType = Objects.requireNonNull(contentType);
+  }
+
+  /**
+   * Conversion constructor.
+   *
+   * @param other The Protocol Buffer representation of a PublishRequest.
+   */
+  public PublishRequest(dapr.proto.components.v1.Pubsub.PublishRequest other) {
+    this(other.getData(),
+        other.getPubsubName(),
+        other.getTopic(),
+        other.getMetadataMap(),
+        other.getContentType());
+  }
+}

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/pubsub/PullMessagesRequest.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/pubsub/PullMessagesRequest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.domain.pubsub;
+
+import java.util.Optional;
+
+public record PullMessagesRequest(Topic topic, String ackMessageId, Optional<String> ackErrorMessage) {
+
+  /**
+   * Conversion constructor.
+   *
+   * @param other The Protocol Buffer representation of a PullMessagesRequest.
+   */
+  public PullMessagesRequest(dapr.proto.components.v1.Pubsub.PullMessagesRequest other) {
+    this(new Topic(other.getTopic()),
+        other.getAckMessageId(),
+        other.hasAckError()
+            ? Optional.of(other.getAckError().getMessage())
+            : Optional.empty());
+  }
+}

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/pubsub/PullMessagesResponse.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/pubsub/PullMessagesResponse.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.domain.pubsub;
+
+import com.google.protobuf.ByteString;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * PullMessagesResponse.
+ *
+ * @param data The message content.
+ * @param topicName The topicName where the message come from.
+ * @param metadata Message metadata.
+ * @param contentType The data content type.
+ * @param id The message {transient} ID. Its used for ack'ing it later.
+ */
+public record PullMessagesResponse(ByteString data, String topicName, Map<String, String> metadata, String contentType,
+                                   String id) {
+  /**
+   * Canonical constructor.
+   *
+   * @param data The message content.
+   * @param topicName The topicName where the message come from.
+   * @param metadata Message metadata.
+   * @param contentType The data content type.
+   * @param id The message {transient} ID. Its used for ack'ing it later.
+   */
+  public PullMessagesResponse(ByteString data, String topicName, Map<String, String> metadata, String contentType,
+                              String id) {
+    this.data = Objects.requireNonNull(data);
+    this.topicName = Objects.requireNonNull(topicName);
+    // All this constructor just so we can make this Map unmodifiable and this class immutable ;)
+    this.metadata = Map.copyOf(Objects.requireNonNull(metadata));
+    this.contentType = Objects.requireNonNull(contentType);
+    this.id = Objects.requireNonNull(id);
+  }
+
+  /**
+   * Conversion constructor.
+   *
+   * @param other The Protocol Buffer representation of a PublishRequest.
+   */
+  public PullMessagesResponse(dapr.proto.components.v1.Pubsub.PullMessagesResponse other) {
+    this(other.getData(),
+        other.getTopicName(),
+        other.getMetadataMap(),
+        other.getContentType(),
+        other.getId());
+  }
+}

--- a/components-java-sdk/src/main/java/io/dapr/components/domain/pubsub/Topic.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/pubsub/Topic.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 The Dapr Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dapr.components.domain.pubsub;
+
+import dapr.proto.components.v1.Pubsub;
+
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Topic.
+ *
+ * @param name The name of the topic.
+ * @param metadata Metadata associated with this topic.
+ */
+public record Topic(String name, Map<String, String> metadata) {
+  /**
+   * Canonical Constructor.
+   *
+   * @param name The name of the topic.
+   * @param metadata Metadata associated with this topic.
+   */
+  public Topic(String name, Map<String, String> metadata) {
+    this.name = Objects.requireNonNull(name);
+    // All this constructor just so we can make this Map unmodifiable and this class immutable ;)
+    this.metadata = Map.copyOf(Objects.requireNonNull(metadata));
+  }
+
+  /**
+   * Conversion constructor.
+   *
+   * @param other The Protocol Buffer representation of a Topic.
+   */
+  public Topic(Pubsub.Topic other) {
+    this(other.getName(),
+        other.getMetadataMap());
+  }
+}


### PR DESCRIPTION
# Description

* Updates code to also download pubsub.proto and generate Java code for it.

Depends on https://github.com/dapr-sandbox/components-java-sdk/pull/24

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
