### PR TITLE
Publish to GH Maven repo upon relase creation.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Publish package to GitHub Packages
+on:
+  release:
+    types: [created]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: Publish package
+        run: mvn --batch-mode deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/components-java-sdk-autogen/pom.xml
+++ b/components-java-sdk-autogen/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.dapr</groupId>
         <artifactId>components-java-sdk-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>components-java-sdk-autogen</artifactId>

--- a/components-java-sdk-examples/pom.xml
+++ b/components-java-sdk-examples/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>io.dapr</groupId>
         <artifactId>components-java-sdk-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>components-java-sdk-examples</artifactId>
     <packaging>jar</packaging>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <name>components-java-sdk-examples</name>
     <description>Examples for Dapr Java Pluggable Components SDK</description>
 

--- a/components-java-sdk/pom.xml
+++ b/components-java-sdk/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>io.dapr</groupId>
         <artifactId>components-java-sdk-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>components-java-sdk</artifactId>
     <packaging>jar</packaging>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <name>components-java-sdk</name>
     <description>SDK for developing Dapr pluggable containers in java</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.dapr</groupId>
     <artifactId>components-java-sdk-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.0-SNAPSHOT</version>
+    <version>${revision}</version>
     <name>components-java-sdk-parent</name>
     <description>Java SDK for Dapr Pluggable Components.</description>
     <url>https://dapr.io</url>
@@ -19,6 +19,10 @@
     </modules>
 
     <properties>
+        <!-- We define the version for all packages in this project only once. -->
+        <!-- Reference https://stackoverflow.com/questions/10582054/.  -->
+        <revision>0.0.2-SNAPSHOT</revision>
+
         <dapr.proto.baseurl>https://raw.githubusercontent.com/dapr/dapr/v1.9.5/dapr/proto</dapr.proto.baseurl>
         <!-- Pin library dependencies to specific versions-->
         <grpc.version>1.42.1</grpc.version>
@@ -148,7 +152,13 @@
 
     <!-- TODO add reporting section -->
 
-    <!-- TODO add distributionManagement -->
+    <distributionManagement>
+        <repository>
+            <id>github</id>
+            <name>GitHub Packages</name>
+            <url>https://maven.pkg.github.com/dapr-sandbox/components-java-sdk</url>
+        </repository>
+    </distributionManagement>
     
     <licenses>
         <license>


### PR DESCRIPTION
# Description

* Setups a GH workflow to plublish packages whenever a new release is created.
* Decreases version to pre-1.0 to communicate better the current state of this code and to avoid publishing a 1.0 release by accident. ;)
* We define the version of every module in this project in a single place using the `revision` property.

References: https://docs.github.com/en/actions/publishing-packages/publishing-java-packages-with-maven

Closes #5


## Test Done

1. On my own fork, I overwrote the contents of `distributionManagement.repository.url` in the parent project .pom  to point to my own fork. See [6e2b74de85df97c3853c7ed7efae156e3ea7d434](https://github.com/dapr-sandbox/components-java-sdk/commit/6e2b74de85df97c3853c7ed7efae156e3ea7d434)
2. Created a new release on that fork. That triggered a release workflow: https://github.com/tmacam/dapr-components-java-sdk/actions/runs/4238760994
3. The result packages: https://github.com/tmacam/dapr-components-java-sdk/packages/1795686

## Issue reference

Please reference the issue this PR will close: #5

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
