### PR TITLE
Stop trying to map on a Mono<Void>.

### DIFF
--- a/components-java-sdk/src/main/java/io/dapr/components/domain/bindings/InvokeRequest.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/domain/bindings/InvokeRequest.java
@@ -44,9 +44,10 @@ public record InvokeRequest(ByteString data, Map<String, String> metadata, Strin
    * Conversion constructor.
    *
    * @param other The Protocol Buffer representation of a InvokeRequest.
+   * @return The provided protocol buffer object converted into the local domain.
    */
-  public InvokeRequest(dapr.proto.components.v1.Bindings.InvokeRequest other) {
-    this(other.getData(),
+  public static InvokeRequest fromProto(dapr.proto.components.v1.Bindings.InvokeRequest other) {
+    return new InvokeRequest(other.getData(),
         other.getMetadataMap(),
         other.getOperation());
   }

--- a/components-java-sdk/src/main/java/io/dapr/components/wrappers/InputBindingGrpcComponentWrapper.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/wrappers/InputBindingGrpcComponentWrapper.java
@@ -43,7 +43,7 @@ public class InputBindingGrpcComponentWrapper extends InputBindingGrpc.InputBind
     Mono.just(request)
         .flatMap(req -> inputBinding.init(req.getMetadata().getPropertiesMap()))
         // Response is functionally and structurally equivalent to Empty, nothing to fill.
-        .map(response -> Bindings.InputBindingInitResponse.getDefaultInstance())
+        .thenReturn(Bindings.InputBindingInitResponse.getDefaultInstance())
         .subscribe(responseObserver::onNext, responseObserver::onError, responseObserver::onCompleted);
   }
 
@@ -52,7 +52,7 @@ public class InputBindingGrpcComponentWrapper extends InputBindingGrpc.InputBind
     Mono.just(request)
         .flatMap(req -> inputBinding.ping())
         // Response is functionally and structurally equivalent to Empty, nothing to fill.
-        .map(successfulPing -> ComponentProtos.PingResponse.getDefaultInstance())
+        .thenReturn(ComponentProtos.PingResponse.getDefaultInstance())
         .subscribe(responseObserver::onNext, responseObserver::onError, responseObserver::onCompleted);
   }
 

--- a/components-java-sdk/src/main/java/io/dapr/components/wrappers/OutputBindingGrpcComponentWrapper.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/wrappers/OutputBindingGrpcComponentWrapper.java
@@ -35,48 +35,40 @@ public class OutputBindingGrpcComponentWrapper extends OutputBindingGrpc.OutputB
   @Override
   public void init(Bindings.OutputBindingInitRequest request,
                    StreamObserver<Bindings.OutputBindingInitResponse> responseObserver) {
-    final Bindings.OutputBindingInitResponse response = Mono.just(request)
+    Mono.just(request)
         .flatMap(req -> outputBinding.init(req.getMetadata().getPropertiesMap()))
         // Response is functionally and structurally equivalent to Empty, nothing to fill.
-        .map(success -> Bindings.OutputBindingInitResponse.getDefaultInstance())
-        .block();
-    responseObserver.onNext(response);
-    responseObserver.onCompleted();
+        .thenReturn(Bindings.OutputBindingInitResponse.getDefaultInstance())
+        .subscribe(responseObserver::onNext, responseObserver::onError, responseObserver::onCompleted);
   }
 
   @Override
   public void ping(ComponentProtos.PingRequest request, StreamObserver<ComponentProtos.PingResponse> responseObserver) {
-    final ComponentProtos.PingResponse response = Mono.just(request)
+    Mono.just(request)
         .flatMap(req -> outputBinding.ping())
         // Response is functionally and structurally equivalent to Empty, nothing to fill.
-        .map(successfulPing -> ComponentProtos.PingResponse.getDefaultInstance())
-        .block();
-    responseObserver.onNext(response);
-    responseObserver.onCompleted();
+        .thenReturn(ComponentProtos.PingResponse.getDefaultInstance())
+        .subscribe(responseObserver::onNext, responseObserver::onError, responseObserver::onCompleted);
   }
 
   @Override
   public void invoke(Bindings.InvokeRequest request, StreamObserver<Bindings.InvokeResponse> responseObserver) {
-    final Bindings.InvokeResponse response = Mono.just(request)
-        .map(InvokeRequest::new) // Convert to local domain/model
+    Mono.just(request)
+        .map(InvokeRequest::fromProto) // Convert to local domain/model
         .flatMap(outputBinding::invoke)
         .map(InvokeResponse::toProto) // convert back to gRPC model
-        .block();
-    responseObserver.onNext(response);
-    responseObserver.onCompleted();
+        .subscribe(responseObserver::onNext, responseObserver::onError, responseObserver::onCompleted);
   }
 
   @Override
   public void listOperations(Bindings.ListOperationsRequest request,
                              StreamObserver<Bindings.ListOperationsResponse> responseObserver) {
-    final Bindings.ListOperationsResponse response = Mono.just(request)
+    Mono.just(request)
         // ListOperations is an empty message, just like PingRequest. Nothing to read from it.
         .flatMap(req -> outputBinding.listOperations())
         .map(operations -> Bindings.ListOperationsResponse.newBuilder()
             .addAllOperations(operations)
             .build())
-        .block();
-    responseObserver.onNext(response);
-    responseObserver.onCompleted();
+        .subscribe(responseObserver::onNext, responseObserver::onError, responseObserver::onCompleted);
   }
 }

--- a/components-java-sdk/src/main/java/io/dapr/components/wrappers/PubSubGrpcComponentWrapper.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/wrappers/PubSubGrpcComponentWrapper.java
@@ -49,7 +49,7 @@ public class PubSubGrpcComponentWrapper extends PubSubGrpc.PubSubImplBase {
     Mono.just(request)
         .flatMap(req -> pubSub.init(req.getMetadata().getPropertiesMap()))
         // Response is functionally and structurally equivalent to Empty, nothing to fill.
-        .map(response -> Pubsub.PubSubInitResponse.getDefaultInstance())
+        .thenReturn(Pubsub.PubSubInitResponse.getDefaultInstance())
         .subscribe(responseObserver::onNext, responseObserver::onError, responseObserver::onCompleted);
   }
 
@@ -70,7 +70,7 @@ public class PubSubGrpcComponentWrapper extends PubSubGrpc.PubSubImplBase {
     Mono.just(request)
         .flatMap(req -> pubSub.ping())
         // Response is functionally and structurally equivalent to Empty, nothing to fill.
-        .map(successfulPing -> ComponentProtos.PingResponse.getDefaultInstance())
+        .thenReturn(ComponentProtos.PingResponse.getDefaultInstance())
         .subscribe(responseObserver::onNext, responseObserver::onError, responseObserver::onCompleted);
   }
 
@@ -80,7 +80,7 @@ public class PubSubGrpcComponentWrapper extends PubSubGrpc.PubSubImplBase {
         .map(PublishRequest::fromProto)
         .flatMap(pubSub::publish)
         // Response is functionally and structurally equivalent to Empty, nothing to fill.
-        .map(success -> Pubsub.PublishResponse.getDefaultInstance())
+        .thenReturn(Pubsub.PublishResponse.getDefaultInstance())
         .subscribe(responseObserver::onNext, responseObserver::onError, responseObserver::onCompleted);
   }
 

--- a/components-java-sdk/src/main/java/io/dapr/components/wrappers/StateStoreGrpcComponentWrapper.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/wrappers/StateStoreGrpcComponentWrapper.java
@@ -61,9 +61,10 @@ public class StateStoreGrpcComponentWrapper extends StateStoreGrpc.StateStoreImp
     Mono.just(request)
         .flatMap(req -> stateStore.init(req.getMetadata().getPropertiesMap()))
         // Response is functionally and structurally equivalent to Empty, nothing to fill.
-        .map(response -> State.InitResponse.getDefaultInstance())
+        .thenReturn(State.InitResponse.getDefaultInstance())
         .subscribe(responseObserver::onNext, responseObserver::onError, responseObserver::onCompleted);
   }
+
 
   @Override
   public void features(final ComponentProtos.FeaturesRequest request,
@@ -83,7 +84,7 @@ public class StateStoreGrpcComponentWrapper extends StateStoreGrpc.StateStoreImp
     Mono.just(request)
         .flatMap(req -> stateStore.ping())
         // Response is functionally and structurally equivalent to Empty, nothing to fill.
-        .map(successfulPing -> ComponentProtos.PingResponse.getDefaultInstance())
+        .thenReturn(ComponentProtos.PingResponse.getDefaultInstance())
         .subscribe(responseObserver::onNext, responseObserver::onError, responseObserver::onCompleted);
   }
 
@@ -93,7 +94,7 @@ public class StateStoreGrpcComponentWrapper extends StateStoreGrpc.StateStoreImp
         .map(io.dapr.components.domain.state.DeleteRequest::fromProto) //Convert to local domain
         .flatMap(stateStore::delete)
         // Response is functionally and structurally equivalent to Empty, nothing to fill.
-        .map(response -> State.DeleteResponse.getDefaultInstance())
+        .thenReturn(State.DeleteResponse.getDefaultInstance())
         .subscribe(responseObserver::onNext, responseObserver::onError, responseObserver::onCompleted);
   }
 
@@ -106,8 +107,8 @@ public class StateStoreGrpcComponentWrapper extends StateStoreGrpc.StateStoreImp
         .map(io.dapr.components.domain.state.DeleteRequest::fromProto)
         .collectList()
         // Perform the bulk operation
-        .map(this.stateStore::bulkDelete)
-        .map(response -> State.BulkDeleteResponse.getDefaultInstance())
+        .flatMap(this.stateStore::bulkDelete)
+        .thenReturn(State.BulkDeleteResponse.getDefaultInstance())
         .subscribe(responseObserver::onNext, responseObserver::onError, responseObserver::onCompleted);
   }
 
@@ -169,7 +170,7 @@ public class StateStoreGrpcComponentWrapper extends StateStoreGrpc.StateStoreImp
         .map(SetRequest::fromProto)  // Convert to local domain/model
         .flatMap(stateStore::set)
         // Response is functionally and structurally equivalent to Empty, nothing to fill.
-        .map(response -> State.SetResponse.getDefaultInstance())
+        .thenReturn(State.SetResponse.getDefaultInstance())
         .subscribe(responseObserver::onNext, responseObserver::onError, responseObserver::onCompleted);
   }
 
@@ -183,7 +184,7 @@ public class StateStoreGrpcComponentWrapper extends StateStoreGrpc.StateStoreImp
         // Perform the bulk operation
         .flatMap(this.stateStore::bulkSet)
         // Response is functionally and structurally equivalent to Empty, nothing to fill.
-        .map(allRequestsWereSuccessful -> State.BulkSetResponse.getDefaultInstance())
+        .thenReturn(State.BulkSetResponse.getDefaultInstance())
         .subscribe(responseObserver::onNext, responseObserver::onError, responseObserver::onCompleted);
   }
 }

--- a/components-java-sdk/src/main/java/io/dapr/components/wrappers/TransactionalStateStoreComponentWrapper.java
+++ b/components-java-sdk/src/main/java/io/dapr/components/wrappers/TransactionalStateStoreComponentWrapper.java
@@ -36,7 +36,7 @@ public class TransactionalStateStoreComponentWrapper
         .map(TransactionalStateRequest::fromProto)
         .flatMap(transactionalStateStore::transact)
         // Response is functionally and structurally equivalent to Empty, nothing to fill.
-        .map(success -> State.TransactionalStateResponse.getDefaultInstance())
+        .thenReturn(State.TransactionalStateResponse.getDefaultInstance())
         .subscribe(responseObserver::onNext, responseObserver::onError, responseObserver::onCompleted);
   }
 }


### PR DESCRIPTION
# Description

Some of our APIs use `Mono<Void>` to signal success or error.  `Ping` is one such API and its default implementation (and that for other similar methods) use `Mono.empty()` to signal success. This makes sense: that Mono will emit an `onComplete` signal and that's it. Besides, there isn't really a sane way emit an item through an `onNext()` on a `Mono<Void>`.  The only signals such Mono would ever produce would be an `onCompleted` or an `onError`. Thus, calling `.map` method on them would not produce any item (as there is no item to map from) and be meaningless.

But our code was indeed calling `map()` and expecting an item to be produced from that. That was resuling in an error from gRPC: a StremObserver had its `onCompleted` invoked but it was expecting a `onNext` to be called before. As that expectation failed, the gRPC call failed.

This PR addresses this by converting those `.map` on `Mono<Void>`s to `.thenReturn`, enforcing the intended behaviour.

Reverts and fix #35.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
